### PR TITLE
Select from Avro-backed Hive table fails when schema is in HDFS

### DIFF
--- a/src/main/java/com/linkedin/haivvreo/HaivvreoUtils.java
+++ b/src/main/java/com/linkedin/haivvreo/HaivvreoUtils.java
@@ -93,7 +93,6 @@ class HaivvreoUtils {
       return s;
     } finally {
       if(in != null) in.close();
-      if(fs != null) fs.close();
     }
   }
 


### PR DESCRIPTION
Hi Jakob,

There's an interesting error case when the Avro schema is read from the same HDFS filesystem that it is reading or writing to. Haivvreo closes the HDFS filesystem object after reading the schema, but since this is a cached object (cached by FileSystem) the subsequent read or write on HDFS fails since the DistributedFileSystem object is now closed. 

I think the simplest solution is not to close the HDFS filesystem object. It will be automatically closed when the task VM terminates.

Thoughts?

Tom
