### PR TITLE
Files in Avro-backed Hive tables do not have a ".avro" extension

### DIFF
--- a/src/main/java/com/linkedin/haivvreo/AvroSerDe.java
+++ b/src/main/java/com/linkedin/haivvreo/AvroSerDe.java
@@ -53,6 +53,8 @@ public class AvroSerDe implements SerDe {
     // so we have to be defensive here
     if (configuration != null) {
       configuration.set(HAIVVREO_SCHEMA, schema.toString(false));
+      // force output files to have a .avro extension
+      configuration.set("hive.output.file.extension", ".avro");
     }
     badSchema = schema.equals(SchemaResolutionProblem.SIGNAL_BAD_SCHEMA);
 


### PR DESCRIPTION
Jakob, you might be interested in this one too. See https://issues.apache.org/jira/browse/HIVE-2457 for the background and dependent Hive patch.

Cheers,
Tom
