### PR TITLE
Make AvroSerde work with Hive 0.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.linkedin</groupId>
   <artifactId>haivvreo</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.13-avro174-hive81</version>
+  <version>1.1.0-avro175-hive12</version>
   <name>haivvreo</name>
   <url>https://github.com/jghoman/haivvreo</url>
   <description>Library for processing Avro data in Hive.</description>
@@ -51,9 +51,9 @@
   </build>
 
   <properties>
-    <avro.version>1.7.4</avro.version>
-    <hive.version>0.8.1</hive.version>
-    <hadoop.version>1.0.2</hadoop.version>
+    <avro.version>1.7.5</avro.version>
+    <hive.version>0.12.0</hive.version>
+    <hadoop.version>1.2.1</hadoop.version>
   </properties>
 
   <repositories>

--- a/src/main/java/com/linkedin/haivvreo/AvroContainerOutputFormat.java
+++ b/src/main/java/com/linkedin/haivvreo/AvroContainerOutputFormat.java
@@ -25,12 +25,15 @@ import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordWriter;
+import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.util.Progressable;
 
 import java.io.IOException;
@@ -70,4 +73,23 @@ public class AvroContainerOutputFormat implements HiveOutputFormat<LongWritable,
     return new AvroGenericRecordWriter(dfw);
   }
 
+  //no records will be emitted from Hive
+  @Override
+  public RecordWriter<LongWritable, AvroGenericRecordWritable>
+  getRecordWriter(FileSystem ignored, JobConf job, String name,
+      Progressable progress) {
+    return new RecordWriter<LongWritable, AvroGenericRecordWritable>() {
+      public void write(LongWritable key, AvroGenericRecordWritable value) {
+        throw new RuntimeException("Should not be called");
+      }
+
+      public void close(Reporter reporter) {
+      }
+    };
+  }
+
+  @Override
+  public void checkOutputSpecs(FileSystem ignored, JobConf job) throws IOException {
+    return; // Not doing any check
+  }  
 }

--- a/src/main/java/com/linkedin/haivvreo/AvroGenericRecordReader.java
+++ b/src/main/java/com/linkedin/haivvreo/AvroGenericRecordReader.java
@@ -26,7 +26,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.Utilities;
-import org.apache.hadoop.hive.ql.plan.MapredWork;
+import org.apache.hadoop.hive.ql.plan.MapWork;
 import org.apache.hadoop.hive.ql.plan.PartitionDesc;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapred.*;
@@ -79,11 +79,11 @@ public class AvroGenericRecordReader implements RecordReader<NullWritable, AvroG
     FileSystem fs = split.getPath().getFileSystem(job);
     // Inside of a MR job, we can pull out the actual properties
     if(HaivvreoUtils.insideMRJob(job)) {
-      MapredWork mapRedWork = Utilities.getMapRedWork(job);
+      MapWork mapWork = Utilities.getMapWork(job);
 
       // Iterate over the Path -> Partition descriptions to find the partition
       // that matches our input split.
-      for (Map.Entry<String,PartitionDesc> pathsAndParts: mapRedWork.getPathToPartitionInfo().entrySet()){
+      for (Map.Entry<String,PartitionDesc> pathsAndParts: mapWork.getPathToPartitionInfo().entrySet()){
         String partitionPath = pathsAndParts.getKey();
         if(pathIsInPartition(split.getPath().makeQualified(fs), partitionPath)) {
           if(LOG.isInfoEnabled()) LOG.info("Matching partition " + partitionPath + " with input split " + split);

--- a/src/main/java/com/linkedin/haivvreo/AvroSerDe.java
+++ b/src/main/java/com/linkedin/haivvreo/AvroSerDe.java
@@ -20,7 +20,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.exec.Utilities;
-import org.apache.hadoop.hive.ql.plan.MapredWork;
+import org.apache.hadoop.hive.ql.plan.MapWork;
 import org.apache.hadoop.hive.ql.plan.PartitionDesc;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.serde2.SerDe;
@@ -89,8 +89,8 @@ public class AvroSerDe implements SerDe {
   private Properties determineCorrectProperties(Configuration configuration, Properties properties) {
     if((configuration instanceof JobConf) && HaivvreoUtils.insideMRJob((JobConf) configuration)) {
       LOG.info("In MR job, extracting table-level properties");
-      MapredWork mapRedWork = Utilities.getMapRedWork(configuration);
-      LinkedHashMap<String,PartitionDesc> a = mapRedWork.getAliasToPartnInfo();
+      MapWork mapWork = Utilities.getMapWork(configuration);
+      LinkedHashMap<String, PartitionDesc> a = mapWork.getAliasToPartnInfo();
       if(a.size() == 1) {
         LOG.info("Only one PartitionDesc found.  Returning that Properties");
         PartitionDesc p = a.values().iterator().next();


### PR DESCRIPTION
- Make Haivvreo work with Hive 0.12.0
- Upgrade Avro dependency from 1.7.4 to 1.7.5
- Upgrade Hadoop dependency to 1.2.1
- Bump the Haivvreo version number from 1.0.13-avro174-hive81 to 1.1.0-avro175-hive12

Note: This change breaks backward compatibility with older versions of Hive.

Testing: Ran the unit tests. They all pass.
