### PR TITLE
Reuse Configuration in HaivvreoUtils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+*.iml
+target

--- a/src/main/java/com/linkedin/haivvreo/AvroContainerOutputFormat.java
+++ b/src/main/java/com/linkedin/haivvreo/AvroContainerOutputFormat.java
@@ -53,7 +53,7 @@ public class AvroContainerOutputFormat implements HiveOutputFormat<LongWritable,
                                                            Progressable progressable) throws IOException {
     Schema schema;
     try {
-      schema = HaivvreoUtils.determineSchemaOrThrowException(properties);
+      schema = HaivvreoUtils.determineSchemaOrThrowException(jobConf, properties);
     } catch (HaivvreoException e) {
       throw new IOException(e);
     }

--- a/src/main/java/com/linkedin/haivvreo/AvroGenericRecordReader.java
+++ b/src/main/java/com/linkedin/haivvreo/AvroGenericRecordReader.java
@@ -90,7 +90,7 @@ public class AvroGenericRecordReader implements RecordReader<NullWritable, AvroG
 
           Properties props = pathsAndParts.getValue().getProperties();
           if(props.containsKey(HaivvreoUtils.SCHEMA_LITERAL) || props.containsKey(HaivvreoUtils.SCHEMA_URL)) {
-            return HaivvreoUtils.determineSchemaOrThrowException(props);
+            return HaivvreoUtils.determineSchemaOrThrowException(job, props);
           } else
             return null; // If it's not in this property, it won't be in any others
         }

--- a/src/main/java/com/linkedin/haivvreo/AvroSerDe.java
+++ b/src/main/java/com/linkedin/haivvreo/AvroSerDe.java
@@ -65,7 +65,7 @@ public class AvroSerDe implements SerDe {
 
     properties = determineCorrectProperties(configuration, properties);
 
-    schema =  HaivvreoUtils.determineSchemaOrReturnErrorSchema(properties);
+    schema =  HaivvreoUtils.determineSchemaOrReturnErrorSchema(configuration, properties);
     if(configuration == null) {
       LOG.info("Configuration null, not inserting schema");
     } else {

--- a/src/main/java/com/linkedin/haivvreo/HaivvreoUtils.java
+++ b/src/main/java/com/linkedin/haivvreo/HaivvreoUtils.java
@@ -47,7 +47,8 @@ class HaivvreoUtils {
    * @throws IOException if error while trying to read the schema from another location
    * @throws HaivvreoException if unable to find a schema or pointer to it in the properties
    */
-  public static Schema determineSchemaOrThrowException(Properties properties) throws IOException, HaivvreoException {
+  public static Schema determineSchemaOrThrowException(Configuration conf, Properties properties)
+      throws IOException, HaivvreoException {
     String schemaString = properties.getProperty(SCHEMA_LITERAL);
     if(schemaString != null && !schemaString.equals(SCHEMA_NONE))
       return Schema.parse(schemaString);
@@ -59,7 +60,7 @@ class HaivvreoUtils {
 
     try {
       if(schemaString.toLowerCase().startsWith("hdfs://"))
-        return getSchemaFromHDFS(schemaString, new Configuration());
+        return getSchemaFromHDFS(schemaString, conf);
     } catch(IOException ioe) {
       throw new HaivvreoException("Unable to read schema from HDFS: " + schemaString, ioe);
     }
@@ -74,9 +75,9 @@ class HaivvreoUtils {
    * any call, including calls to update the serde properties, meaning
    * if the serde is in a bad state, there is no way to update that state.
    */
-  public static Schema determineSchemaOrReturnErrorSchema(Properties props) {
+  public static Schema determineSchemaOrReturnErrorSchema(Configuration conf, Properties props) {
     try {
-      return determineSchemaOrThrowException(props);
+      return determineSchemaOrThrowException(conf, props);
     } catch(HaivvreoException he) {
       LOG.warn("Encountered HaivvreoException determining schema. Returning signal schema to indicate problem", he);
       return SchemaResolutionProblem.SIGNAL_BAD_SCHEMA;

--- a/src/test/java/com/linkedin/haivvreo/TestHaivvreoUtils.java
+++ b/src/test/java/com/linkedin/haivvreo/TestHaivvreoUtils.java
@@ -108,26 +108,29 @@ public class TestHaivvreoUtils {
 
   @Test(expected=HaivvreoException.class)
   public void determineSchemaThrowsExceptionIfNoSchema() throws IOException, HaivvreoException {
+    Configuration conf = new Configuration();
     Properties prop = new Properties();
-    HaivvreoUtils.determineSchemaOrThrowException(prop);
+    HaivvreoUtils.determineSchemaOrThrowException(conf, prop);
   }
 
   @Test
   public void determineSchemaFindsLiterals() throws Exception {
     String schema = TestAvroObjectInspectorGenerator.RECORD_SCHEMA;
+    Configuration conf = new Configuration();
     Properties props = new Properties();
     props.put(HaivvreoUtils.SCHEMA_LITERAL, schema);
     Schema expected = Schema.parse(schema);
-    assertEquals(expected, HaivvreoUtils.determineSchemaOrThrowException(props));
+    assertEquals(expected, HaivvreoUtils.determineSchemaOrThrowException(conf, props));
   }
 
   @Test
   public void detemineSchemaTriesToOpenUrl() throws HaivvreoException, IOException {
+    Configuration conf = new Configuration();
     Properties props = new Properties();
     props.put(HaivvreoUtils.SCHEMA_URL, "not:///a.real.url");
 
     try {
-      HaivvreoUtils.determineSchemaOrThrowException(props);
+      HaivvreoUtils.determineSchemaOrThrowException(conf, props);
       fail("Should have tried to open that URL");
     } catch(MalformedURLException e) {
       assertEquals("unknown protocol: not", e.getMessage());
@@ -136,13 +139,14 @@ public class TestHaivvreoUtils {
 
   @Test
   public void noneOptionWorksForSpecifyingSchemas() throws IOException, HaivvreoException {
+    Configuration conf = new Configuration();
     Properties props = new Properties();
 
     // Combo 1: Both set to none
     props.put(SCHEMA_URL, SCHEMA_NONE);
     props.put(SCHEMA_LITERAL, SCHEMA_NONE);
     try {
-      determineSchemaOrThrowException(props);
+      determineSchemaOrThrowException(conf, props);
       fail("Should have thrown exception with none set for both url and literal");
     } catch(HaivvreoException he) {
       assertEquals(EXCEPTION_MESSAGE, he.getMessage());
@@ -152,7 +156,7 @@ public class TestHaivvreoUtils {
     props.put(SCHEMA_LITERAL, TestAvroObjectInspectorGenerator.RECORD_SCHEMA);
     Schema s;
     try {
-      s = determineSchemaOrThrowException(props);
+      s = determineSchemaOrThrowException(conf, props);
       assertNotNull(s);
       assertEquals(Schema.parse(TestAvroObjectInspectorGenerator.RECORD_SCHEMA), s);
     } catch(HaivvreoException he) {
@@ -163,7 +167,7 @@ public class TestHaivvreoUtils {
     props.put(SCHEMA_LITERAL, SCHEMA_NONE);
     props.put(SCHEMA_URL, "not:///a.real.url");
     try {
-      determineSchemaOrThrowException(props);
+      determineSchemaOrThrowException(conf, props);
       fail("Should have tried to open that bogus URL");
     } catch(MalformedURLException e) {
       assertEquals("unknown protocol: not", e.getMessage());


### PR DESCRIPTION
I am getting an issue where the original Configuration has some parameters needed to read the remote Avro schema (specifically S3 keys).
Doing new Configuration doesn't pick it up because the keys are not on the classpath.
We should reuse the Configuration already present in callers.